### PR TITLE
Add page refresh Api after the stroke addition

### DIFF
--- a/ImageTranscription/main.lua
+++ b/ImageTranscription/main.lua
@@ -31,5 +31,6 @@ function drawStroke()
             ["allowUndoRedoAction"] = "grouped",
         })
     end
+    app.refreshPage() -- Refreshes the page after inserting the strokes.
     print("Image Transcription Complete. Exiting Inkpath.")
 end


### PR DESCRIPTION
Add page refresh Api after the stroke addition, refreshes the page to show the inserted strokes instantly