### PR TITLE
Add a few optimizations to Lua script

### DIFF
--- a/ImageTranscription/main.lua
+++ b/ImageTranscription/main.lua
@@ -7,23 +7,23 @@ end
 -- Callback if the menu item is executed
 function drawStroke()
     print("Inkpath Activated. Transcribing image....")
-    inkpath = assert(package.loadlib("/usr/share/xournalpp/plugins/ImageTranscription/ipcvobj.so", "luaopen_ipcvobj"))
+    local inkpath = assert(package.loadlib("/usr/share/xournalpp/plugins/ImageTranscription/ipcvobj.so", "luaopen_ipcvobj"))
     inkpath()
-    path = app.getFilePath({'*.jpg', '*.png', '*.bmp'}) -- The current version of Autotrace I'm using only supports PNGs.
+    local path = app.getFilePath({'*.jpg', '*.png', '*.bmp'}) -- The current version of Autotrace I'm using only supports PNGs.
     --image_scale = app.msgbox("Select tracing scale", {[1] = "Small", [2] = "Medium", [3] = "Large"}) -- TODO: implement this again.
-    image_scale = 1
-    scaling_factor = 10.0 -- how much do you want to divide your content by? must be float!
+    local image_scale = 1
+    local scaling_factor = 10.0 -- how much do you want to divide your content by? must be float!
     local obj = IPCVObj(path, 1)
     print("Strokes retrieved.")
-    contourCt = obj:getLength()
+    local contourCt = obj:getLength()
     print("Got ", contourCt, " strokes.")
     -- TODO: This could be much, MUCH faster.
     for i = 0,contourCt-1,1 do
-        pointCt = obj:getContourLength(i)
+        local pointCt = obj:getContourLength(i)
         -- We have no use for strokes that are less than two points---we can't do
         -- anything with them.
         if pointCt >= 3 then
-            x_points, y_points = obj:getContour(i, scaling_factor)
+            local x_points, y_points = obj:getContour(i, scaling_factor)
             app.addStrokes({
                 ["strokes"] = {
                     {

--- a/ImageTranscription/main.lua
+++ b/ImageTranscription/main.lua
@@ -12,7 +12,7 @@ function drawStroke()
     path = app.getFilePath({'*.jpg', '*.png', '*.bmp'}) -- The current version of Autotrace I'm using only supports PNGs.
     --image_scale = app.msgbox("Select tracing scale", {[1] = "Small", [2] = "Medium", [3] = "Large"}) -- TODO: implement this again.
     image_scale = 1
-    scaling_factor = 10.0 -- THIS IS A NEW THING! HOW MUCH DO YOU WANT TO DIVIDE YOUR SHIT BY!? MUST BE FLOAT!
+    scaling_factor = 10.0 -- how much do you want to divide your content by? must be float!
     local obj = IPCVObj(path, 1)
     print("Strokes retrieved.")
     contourCt = obj:getLength()
@@ -20,16 +20,21 @@ function drawStroke()
     -- TODO: This could be much, MUCH faster.
     for i = 0,contourCt-1,1 do
         pointCt = obj:getContourLength(i)
-        x_points, y_points = obj:getContour(i, scaling_factor)
-        app.addStrokes({
-            ["strokes"] = {
-                {
-                    ["x"] = x_points,
-                    ["y"] = y_points,
+        -- We have no use for strokes that are less than two points---we can't do
+        -- anything with them.
+        if pointCt >= 3 then
+            x_points, y_points = obj:getContour(i, scaling_factor)
+            app.addStrokes({
+                ["strokes"] = {
+                    {
+                        ["x"] = x_points,
+                        ["y"] = y_points,
+                        ["tool"] = "pen", -- Default to pen to silence warnings. TODO: Delete in the future.
+                    },
                 },
-            },
-            ["allowUndoRedoAction"] = "grouped",
-        })
+                ["allowUndoRedoAction"] = "grouped",
+            })
+        end
     end
     app.refreshPage() -- Refreshes the page after inserting the strokes.
     print("Image Transcription Complete. Exiting Inkpath.")


### PR DESCRIPTION
- Discard contours shorter than 3 points (~ -3 sec)
- Default to pen tool (-2 sec)

Takes the tracing of one of my samples from 16 seconds down to 12 seconds. I think these optimizations are generally safe and will slightly improve performance because they are silencing warnings from the Xournal++ API. I wonder if dropping the strokes in C++ might give us even more speed.