### PR TITLE
Add CMake support for building OpenCV statically

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,9 +23,21 @@ file(GLOB PLUGIN_SOURCES src/plugin/*.cpp)
 file(GLOB DEBUG_SOURCES src/cv/debug/*.cpp)
 
 # Locate dependent packages
-FIND_PACKAGE(OpenCV REQUIRED)
-INCLUDE_DIRECTORIES(${OpenCV_INCLUDE_DIRS})
-                            
+option(USE_EXTERNAL_OPENCV_STATIC "Link OpenCV statically (from subdirectory)" OFF)
+IF(USE_EXTERNAL_OPENCV_STATIC)
+	add_subdirectory(external/opencv_static)
+	IF(EXISTS "${OpenCV_DIR}")
+		# Require that the package is only being detected using the provided path from external project
+		FIND_PACKAGE(OpenCV 4.5.1 REQUIRED COMPONENTS core imgproc imgcodecs calib3d NO_DEFAULT_PATH)
+	ENDIF()
+ELSE()
+	FIND_PACKAGE(OpenCV 4.5.1 REQUIRED COMPONENTS core imgproc imgcodecs calib3d)
+ENDIF()
+IF(OpenCV_FOUND)
+	message(STATUS "OpenCV_INCLUDE_DIRS: ${OpenCV_INCLUDE_DIRS}")
+	message(STATUS "OpenCV_LIBRARIES: ${OpenCV_LIBRARIES}")
+ENDIF()
+
 FIND_PACKAGE(Lua 5.4 REQUIRED)
 INCLUDE_DIRECTORIES(${LUA_INCLUDE_DIR})
 
@@ -43,15 +55,22 @@ ELSE()
 	# can build our debug program and such.
 	ADD_LIBRARY(ipcv STATIC ${CV_SOURCES})
 	target_link_libraries(ipcv ${OpenCV_LIBRARIES})
+	target_include_directories(ipcv PRIVATE ${OpenCV_INCLUDE_DIRS})
 
 	# Compile plugin component of Inkpath.
 	ADD_LIBRARY(inkpath SHARED ${PLUGIN_SOURCES})
 	target_compile_options(inkpath PRIVATE)
 	target_link_libraries(inkpath ipcv)
+
+	# Add dependencies if required by given options
+	IF(USE_EXTERNAL_OPENCV_STATIC)
+		add_dependencies(ipcv ExternalOpenCVStatic)
+	ENDIF()
 ENDIF()
 
 # OpenCV Gets linked the same way for both platforms
 target_link_libraries(inkpath ${OpenCV_LIBRARIES})
+target_include_directories(inkpath PRIVATE ${OpenCV_INCLUDE_DIRS})
 
 
 # Copy the script and manifest into the build artifact
@@ -68,8 +87,15 @@ add_executable(inkpath-debug EXCLUDE_FROM_ALL ${CV_SOURCES} ${DEBUG_SOURCES})
 target_compile_definitions(inkpath-debug PRIVATE INKPATH_DEBUG)
 
 target_link_libraries(inkpath-debug ${OpenCV_LIBRARIES})
+target_include_directories(inkpath-debug PRIVATE ${OpenCV_INCLUDE_DIRS})
 set_target_properties(inkpath-debug PROPERTIES OUTPUT_NAME "inkpath-debug")
 set_target_properties(inkpath-debug PROPERTIES RUNTIME_OUTPUT_DIRECTORY "debug")
+
+# Add dependencies if required by given options
+IF(USE_EXTERNAL_OPENCV_STATIC)
+	add_dependencies(${PROJECT_NAME} ExternalOpenCVStatic)
+	add_dependencies(${PROJECT_NAME}-debug ExternalOpenCVStatic)
+ENDIF()
 
 # If cross compiling on Windows copy dependent DLLs
 if(CMAKE_GENERATOR STREQUAL "MinGW Makefiles")

--- a/README.md
+++ b/README.md
@@ -71,11 +71,15 @@ _Inkpath is coming to a package manager near you soon™!_
 
 ### Linux
 
-```
-mkdir build
-cd build
-cmake ..
-make
+```sh
+# Configure
+# > with shared libraries
+cmake -B build -S .
+# > with OpenCV statically linked
+cmake -B build -S . -DUSE_EXTERNAL_OPENCV_STATIC=ON
+# Build and Install
+cmake --build build -j$(nproc)
+cmake --install build
 ```
 
 ### Arch

--- a/external/opencv_static/CMakeLists.txt
+++ b/external/opencv_static/CMakeLists.txt
@@ -1,0 +1,66 @@
+cmake_minimum_required(VERSION 3.22.1)
+project(ExternalOpenCVStatic)
+
+include(ExternalProject)
+
+# Add option to disable since this crashes on some CPUs because of SSE3 problems
+option(DISABLE_WEBP_EXTERNAL_OPENCV "Disable OpenCV library 3rd party dependency for WEBP (from subdirectory)" OFF)
+
+# Set where to build and install OpenCV
+set(OPENCV_BUILD_DIR "${CMAKE_BINARY_DIR}/${PROJECT_NAME}")
+set(OPENCV_INSTALL_DIR "${CMAKE_BINARY_DIR}/${PROJECT_NAME}_install")
+# Set the URL to clone OpenCV from GitHub
+set(OPENCV_TAG "4.11.0")
+set(OPENCV_URL "https://github.com/opencv/opencv.git")
+
+# Expose OpenCV_DIR so the main project can find the installed OpenCV
+set(OpenCV_DIR "${OPENCV_INSTALL_DIR}/lib/cmake/opencv4" PARENT_SCOPE)
+
+# Clone and build OpenCV
+ExternalProject_Add(
+    ${PROJECT_NAME}
+    PREFIX ${OPENCV_BUILD_DIR}
+    GIT_REPOSITORY ${OPENCV_URL}
+    GIT_TAG ${OPENCV_TAG}
+    GIT_SHALLOW TRUE
+    GIT_PROGRESS TRUE
+    CMAKE_ARGS
+        -DCMAKE_INSTALL_PREFIX=${OPENCV_INSTALL_DIR}
+        -DBUILD_SHARED_LIBS=OFF
+        -DCMAKE_BUILD_TYPE=Release
+        -DOPENCV_GENERATE_PKGCONFIG=ON
+        # Require image support
+        -DWITH_AVIF=ON
+        -DWITH_JPEG=ON
+        -DWITH_PNG=ON
+        -DWITH_TIFF=ON
+        -DWITH_WEBP=$<IF:$<BOOL:${DISABLE_WEBP_EXTERNAL_OPENCV}>,OFF,ON>
+        # Disable tests, docs, ...
+        -DBUILD_TESTS=OFF
+        -DBUILD_DOCS=OFF
+        -DBUILD_EXAMPLES=OFF
+        -DBUILD_PERF_TESTS=OFF
+        # Disable unnecessary functionality
+        -DWITH_FFMPEG=OFF
+        -DWITH_GSTREAMER=OFF
+        -DWITH_GTK=OFF
+        -DWITH_OPENEXR=OFF
+        -DWITH_QT=OFF
+        -DBUILD_opencv_java=OFF
+        -DBUILD_opencv_python3=OFF
+        # Disable unnecessary modules
+        -DBUILD_opencv_highgui=OFF
+        -DBUILD_opencv_ml=OFF
+        -DBUILD_opencv_objdetect=OFF
+        -DBUILD_opencv_stitching=OFF
+        -DBUILD_opencv_video=OFF
+        -DBUILD_opencv_videoio=OFF
+    # Declare expected output files that will be generated after the external project is built
+    BUILD_BYPRODUCTS "${OpenCV_DIR}/OpenCVConfig.cmake"
+)
+
+add_custom_command(
+    TARGET ${PROJECT_NAME} POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -S ${CMAKE_SOURCE_DIR} -B ${CMAKE_BINARY_DIR}
+    COMMENT "Re-running CMake to configure ${PROJECT_NAME}"
+)


### PR DESCRIPTION
With this integration it is possible to build OpenCV with static libraries from scratch with the addition of a single CMake argument `-DUSE_EXTERNAL_OPENCV_STATIC=ON`.