### PR TITLE
Update CMake to copy MinGW DLLs automatically after each build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,10 +60,6 @@ FOREACH(FILE ${PLUGIN_FILES})
 	file(COPY ${FILE} DESTINATION ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
 ENDFOREACH()
 
-IF(WIN32)
-	install(CODE "execute_process(COMMAND bash \"${CMAKE_SOURCE_DIR}/scripts/copy_dlls.sh\")")
-ENDIF()
-
 # Finally, set an install target.
 install(DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY} DESTINATION ${INSTALL_DESTINATION})
 
@@ -74,3 +70,17 @@ target_compile_definitions(inkpath-debug PRIVATE INKPATH_DEBUG)
 target_link_libraries(inkpath-debug ${OpenCV_LIBRARIES})
 set_target_properties(inkpath-debug PROPERTIES OUTPUT_NAME "inkpath-debug")
 set_target_properties(inkpath-debug PROPERTIES RUNTIME_OUTPUT_DIRECTORY "debug")
+
+# If cross compiling on Windows copy dependent DLLs
+if(CMAKE_GENERATOR STREQUAL "MinGW Makefiles")
+    add_custom_command(
+        TARGET ${PROJECT_NAME}
+        POST_BUILD
+        COMMAND
+            ldd "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/lib${PROJECT_NAME}.dll" | grep
+            mingw64 | awk "{ print \$3 }" | xargs -I {} cp {}
+            ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
+        COMMENT "Copying ${PROJECT_NAME} dependent MinGW DLLs"
+        VERBATIM
+    )
+endif()


### PR DESCRIPTION
This runs the same command as `scripts/copy_dlls.sh`, but it does it automatically after each successful build with no further interaction required.