### PR TITLE
Feature add CI/CD GitHub Actions

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,0 +1,122 @@
+name: Deploy
+
+on:
+  # Run CI when a new branch or tag is created
+  create:
+    # only run if the tag is a supported version tag
+    tags:
+      - "v*.*.*"
+  # Run CI when a new commit is pushed
+  push:
+    branches:
+      - master
+  # Run CI on pull requests to any branch
+  pull_request:
+  # Run CI on manual request
+  workflow_dispatch:
+
+env:
+  PLUGIN_NAME: ImageTranscription
+
+jobs:
+  push-deploy:
+    strategy:
+        matrix:
+          os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    env:
+      OS_NAME: ${{ startsWith(matrix.os, 'windows') && 'win' || 'linux' }}
+      APT_PACKAGES: |
+        build-essential
+        cmake
+        git
+        liblua5.4-dev
+        pkg-config
+      MSYS2_PACKAGES: |
+        base-devel
+        git
+        mingw-w64-x86_64-cmake
+        mingw-w64-x86_64-lua
+        mingw-w64-x86_64-opencv
+        mingw-w64-x86_64-toolchain
+        pkg-config
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        if: startsWith(matrix.os, 'ubuntu')
+        run: |
+          sudo apt update
+          echo "$APT_PACKAGES" | xargs sudo apt install -y
+
+      - name: Set up MSYS2
+        if: startsWith(matrix.os, 'windows')
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: MINGW64
+          update: true
+          install: ${{ env.MSYS2_PACKAGES }}
+
+      - name: Build using CMake [MSYS2]
+        if: startsWith(matrix.os, 'windows')
+        shell: msys2 {0}
+        run: |
+          cmake -B build -S .
+          cmake --build build -j$(nproc)
+          cmake --install build
+
+      - name: Build using CMake
+        if: startsWith(matrix.os, 'ubuntu')
+        run: |
+          cmake -B build -S . -DUSE_EXTERNAL_OPENCV_STATIC=ON
+          cmake --build build -j$(nproc)
+          cmake --install build
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.PLUGIN_NAME }}-${{ env.OS_NAME }}
+          path: build/${{ env.PLUGIN_NAME }}
+        continue-on-error: true
+
+  create-github-release:
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    # Only create a GitHub release if a new tag was pushed that starts with v
+    # and if the build step was successful
+    needs: push-deploy
+    if: startsWith(github.ref, 'refs/tags/v')
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v4
+    - name: Download all artifacts
+      uses: actions/download-artifact@v4
+      with:
+        path: ./artifacts
+    # This downloads all build steps artifacts into the directory 'artifacts':
+    # - ${{ env.PLUGIN_NAME }}-${{ env.OS_NAME }}
+    # - ...
+    - name: Copy Windows scripts to Windows artifact
+      run: |
+        cp ./scripts/win_configure_path.ps1 ./artifacts/${{ env.PLUGIN_NAME }}-win
+    - name: Create ZIP files for directories
+      run: |
+        zip -r ./${{ env.PLUGIN_NAME }}-linux.zip ./${{ env.PLUGIN_NAME }}-linux
+        zip -r ./${{ env.PLUGIN_NAME }}-win.zip ./${{ env.PLUGIN_NAME }}-win
+      working-directory: ./artifacts
+    - name: Release
+      uses: softprops/action-gh-release@v2
+      with:
+        body_path: RELEASE_NOTES_TEMPLATE.md
+        generate_release_notes: true
+        # Mark as prerelease if tag ends with b
+        prerelease: ${{ endsWith(github.ref_name, 'b') }}
+        files: |
+          ./artifacts/*.zip
+    # This creates a release for the current (new) version tag that includes:
+    # - all created plugin directories as .zip files
+    # - ...

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,17 +27,15 @@ FIND_PACKAGE(OpenCV REQUIRED)
 INCLUDE_DIRECTORIES(${OpenCV_INCLUDE_DIRS})
                             
 FIND_PACKAGE(Lua 5.4 REQUIRED)
+message(STATUS "LUA_INCLUDE_DIR: ${LUA_INCLUDE_DIR}")
+message(STATUS "LUA_LIBRARIES: ${LUA_LIBRARIES}")
 INCLUDE_DIRECTORIES(${LUA_INCLUDE_DIR})
 
 # We link OpenCV statically in Linux,
 # but link totally dynamically and redistribute dlls in Windows
 IF(WIN32)
-	# FIXME (wdn): Fix FIND_PACKAGE behavior for Lua on Windows
-	set(LUA_INCLUDE_DIR "C:/msys64/mingw64/include")
-	set(LUA_LIBRARIES "C:/msys64/mingw64/lib")
-
 	ADD_LIBRARY(inkpath SHARED ${CV_SOURCES} ${PLUGIN_SOURCES})
-	target_link_libraries(inkpath ${LUA_LIBRARIES}/liblua.a)
+	target_link_libraries(inkpath ${LUA_LIBRARIES})
 ELSE()
 	# Compile the CV component of Inkpath separately. This is mostly so that we
 	# can build our debug program and such.

--- a/RELEASE_NOTES_TEMPLATE.md
+++ b/RELEASE_NOTES_TEMPLATE.md
@@ -1,0 +1,12 @@
+Unzip the archive for your operating system and copy that directory to the `plugins` directory of your Xournal++ installation (*Shared resources folder* or *Config folder*[^XOURNALPP_INSTALLATION_FOLDER]).
+
+[^XOURNALPP_INSTALLATION_FOLDER]: https://xournalpp.github.io/guide/plugins/plugins/#installation-folder
+
+To get the plugin custom icon to show up when adding the toolbar icon for a plugin, copy the `.svg` file in the plugin directory to a GTK supported icon location (e.g. `$HOME/.local/share/icons/` or `/usr/share/icons/` on Linux and `%LOCALAPPDATA%\icons\` or `%PROGRAM_FILES%\Xournal++\share\icons\` on Windows).
+
+**Windows:**
+
+If the plugin directory contains `.dll` files this additionally requires adding the directory to the `PATH` environment variable so that the contained `.dll` files can be found when loading main plugin `.dll` file from Lua in Xournal++.
+
+To do this search for *Edit Environment variables for your account* in the Windows search, click *Environment Variables*, on the upper list of the User variables click the existing entry `Path` and add a new directory path of the plugin directory (e.g. `%LOCALAPPDATA%\xournalpp\plugins\PLUGIN_NAME`).
+After applying the changes Xournal++ needs to be restarted.


### PR DESCRIPTION
Adds GitHub Actions that run on every push to the `master` branch and on every git version tag creation (and if a new branch is created).
It builds the plugin and if it's a version creates automatically a release with the built plugin.

> [!IMPORTANT]
>
> This builds up on the build system pull requests #50 , #51 , #52 .

Demo of an automated commit run: https://github.com/AnonymerNiklasistanonym/inkpath/actions/runs/13403371426